### PR TITLE
Add line end pattern sign

### DIFF
--- a/git-diff-lint
+++ b/git-diff-lint
@@ -36,7 +36,7 @@ while getopts ":x:b:e:h" opt; do
   esac
 done
 
-DIFF=$(git diff --name-only --diff-filter=d $(git merge-base HEAD $BRANCH) | grep -E $EXT)
+DIFF=$(git diff --name-only --diff-filter=d $(git merge-base HEAD $BRANCH) | grep -E $EXT$)
 
 printf "Linting following changed files\n"
 printf "$DIFF\n"


### PR DESCRIPTION
If there's no `$` at the end of pattern argument for `grep`, it matches files not with exact extension, but with extension starts with `$EXT`. So if you pass `.js` you get `.json` files in the list too.